### PR TITLE
Keyboard state maintained within global Kernel object

### DIFF
--- a/src/drivers/keyboard.rs
+++ b/src/drivers/keyboard.rs
@@ -2,6 +2,8 @@ use io::Port;
 
 use schedule::bottom_half::BottomHalf;
 
+use kernel::kget;
+
 static CHARS: [u8; 59] = *b"??1234567890-=\x08?qwertyuiop[]\n?asdfghjkl;'`?\\zxcvbnm,./?*? ?";
 static CHARS_SHIFT: [u8; 59] = *b"??!@#$%^&*()_+??QWERTYUIOP{}\n?ASDFGHJKL:\"~?|ZXCVBNM<>??*? ?";
 
@@ -44,10 +46,8 @@ impl Keyboard {
             None
         }
     }
-}
 
-impl BottomHalf for Keyboard {
-    fn execute(&mut self) {
+    fn handle_keypress(&mut self) {
         // Get the code of the keypress
         let code = unsafe {
             let c = self.port.read();
@@ -75,5 +75,20 @@ impl BottomHalf for Keyboard {
                 }
             }
         }
+    }
+}
+
+pub struct KeyboardBottomHalf {}
+
+impl KeyboardBottomHalf {
+    pub fn new() -> KeyboardBottomHalf {
+        KeyboardBottomHalf {}
+    }
+}
+
+impl BottomHalf for KeyboardBottomHalf {
+    fn execute(&mut self) {
+        let driver = unsafe { &mut *kget().keyboard.get() };
+        driver.handle_keypress();
     }
 }

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -1,5 +1,9 @@
 mod rtc;
 mod keyboard;
 
-pub use self::keyboard::Keyboard;
+// Drivers
 pub use self::rtc::Clock;
+pub use self::keyboard::Keyboard;
+
+// Bottom Halves
+pub use self::keyboard::KeyboardBottomHalf;

--- a/src/interrupts/mod.rs
+++ b/src/interrupts/mod.rs
@@ -102,7 +102,7 @@ unsafe fn irq1() {
     let scheduler = &*kget().scheduler.get();
 
     let bh_manager = scheduler.bh_manager();
-    let keyboard = box drivers::Keyboard::new();
+    let bh = box drivers::KeyboardBottomHalf::new();
 
-    bh_manager.add_bh(keyboard);
+    bh_manager.add_bh(bh);
 }

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -1,10 +1,11 @@
 use alloc::boxed::Box;
+
 use core::cell::UnsafeCell;
 
 use schedule::Scheduler;
 use memory::MemoryManager;
 
-use drivers::Clock;
+use drivers;
 
 // The main Kernel pointer, providing access to key objects
 pub static mut PKERNEL: Option<&'static mut Kernel> = None;
@@ -58,7 +59,10 @@ pub fn kget() -> &'static Kernel {
 pub struct Kernel {
     pub scheduler: UnsafeCell<Scheduler>,
     pub memory_manager: UnsafeCell<MemoryManager>,
-    pub clock: UnsafeCell<Clock>,
+
+    // Drivers
+    pub clock: UnsafeCell<drivers::Clock>,
+    pub keyboard: UnsafeCell<drivers::Keyboard>,
 }
 
 impl Kernel {
@@ -66,7 +70,10 @@ impl Kernel {
         Kernel {
             scheduler: UnsafeCell::new(Scheduler::new(&mut memory_manager)),
             memory_manager: UnsafeCell::new(memory_manager),
-            clock: UnsafeCell::new(Clock::new()),
+
+            // Drivers
+            clock: UnsafeCell::new(drivers::Clock::new()),
+            keyboard: UnsafeCell::new(drivers::Keyboard::new()),
         }
     }
 }


### PR DESCRIPTION
KeyboardBottomHalf struct created to handle execution of interrupt
handler without state. Looks up global state and then updates it.